### PR TITLE
Add hourly price data

### DIFF
--- a/custom_components/tibber_data/const.py
+++ b/custom_components/tibber_data/const.py
@@ -73,4 +73,14 @@ TIBBER_APP_SENSORS: tuple[SensorEntityDescription, ...] = (
         name="Grid price",
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    SensorEntityDescription(
+        key="energy_price",
+        name="Energy price",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="total_price",
+        name="Total price",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 )

--- a/custom_components/tibber_data/data_coordinator.py
+++ b/custom_components/tibber_data/data_coordinator.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 from typing import List, Set
+from random import randrange
 
 import tibber
 from homeassistant.components.sensor import (
@@ -101,12 +102,14 @@ class TibberDataCoordinator(DataUpdateCoordinator):
                 data["grid_price"][
                     dt_util.parse_datetime(price_info["time"])
                 ] = price_info["gridPrice"]
-
-        if now.hour < 15:
-            return now.replace(hour=15, minute=0, second=0, microsecond=0)
+            # Add all hourly entries to data
+            data["hourly_prices"] = home["subscription"]["priceRating"]["hourly"]["entries"]
+            
+        # make update happen between 13.15 and 13.30
+        if now.hour < 13 and now.minute < 15:
+            return now.replace(hour=13, minute=15, second=0, microsecond=0) + datetime.timedelta(seconds=randrange(60*15))
         return now.replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ) + datetime.timedelta(days=1)
+            hour=13, minute=15, second=0, microsecond=0) + datetime.timedelta(days=1) + datetime.timedelta(seconds=randrange(60*15))
 
     async def _get_charger_data_tibber(self, data, now):
         """Update charger data via Tibber API."""

--- a/custom_components/tibber_data/helpers.py
+++ b/custom_components/tibber_data/helpers.py
@@ -101,7 +101,7 @@ async def get_tibber_data(session, token: str):
                 "        addressText\n      }\n      subscription {\n"
                 "        priceRating {\n          hourly {\n"
                 "            entries {\n              time\n"
-                "              gridPrice\n            }\n"
+                "              gridPrice\n              total\n            }\n"
                 "          }\n        }\n      }\n    }\n  }\n}\n",
             }
         ),

--- a/custom_components/tibber_data/sensor.py
+++ b/custom_components/tibber_data/sensor.py
@@ -95,13 +95,7 @@ class TibberDataSensor(SensorEntity, CoordinatorEntity["TibberDataCoordinator"])
                 native_value = None
         elif self.entity_description.key == "grid_price":
 
-            self._attr_extra_state_attributes = {
-            "today": None,
-            "raw_today": None,
-            "tomorrow_valid": False,
-            "tomorrow": None,
-            "raw_tomorrow": None,
-            }
+            self._attr_extra_state_attributes = {}
             local_today = []
             local_raw_today = []
             local_tomorrow = []
@@ -122,6 +116,7 @@ class TibberDataSensor(SensorEntity, CoordinatorEntity["TibberDataCoordinator"])
                 if (len(local_tomorrow) > 0):
                     self._attr_extra_state_attributes["tomorrow_valid"] = True
                 else:
+                    self._attr_extra_state_attributes["tomorrow_valid"] = False
                     _LOGGER.debug("No priceinfo for tomorrow")
                 self._attr_extra_state_attributes["tomorrow"] = local_tomorrow
                 self._attr_extra_state_attributes["raw_tomorrow"] = local_raw_tomorrow
@@ -147,14 +142,7 @@ class TibberDataSensor(SensorEntity, CoordinatorEntity["TibberDataCoordinator"])
                 
         elif self.entity_description.key == "energy_price":
             
-            self._attr_extra_state_attributes = {
-            #"raw_data": None,
-            "today": None,
-            "raw_today": None,
-            "tomorrow_valid": False,
-            "tomorrow": None,
-            "raw_tomorrow": None,
-            }
+            self._attr_extra_state_attributes = {}
             
             priceinfo = self.coordinator.data.get("hourly_prices", {})
             # find current price
@@ -163,7 +151,6 @@ class TibberDataSensor(SensorEntity, CoordinatorEntity["TibberDataCoordinator"])
                 if dt_util.parse_datetime(i["time"]) == now_hour:
                     native_value = i["total"]
             
-            #self._attr_extra_state_attributes["raw_data"] = priceinfo
             local_today = []
             local_raw_today = []
             local_tomorrow = []
@@ -176,27 +163,21 @@ class TibberDataSensor(SensorEntity, CoordinatorEntity["TibberDataCoordinator"])
                 if (dt_util.parse_datetime(entry["time"]).date() == (dt_util.now().date() + datetime.timedelta(days=1)) ):
                     local_tomorrow.append(entry["total"])
                     local_raw_tomorrow.append({"time":entry["time"],"total":entry["total"]})
-                # add total with grid price to raw data
-                #entry["total_with_gridPrice"] = round(entry["total"] + entry["gridPrice"], 4)
 
             self._attr_extra_state_attributes["today"] = local_today
             self._attr_extra_state_attributes["raw_today"] = local_raw_today
             if (len(local_tomorrow) > 0):
                 self._attr_extra_state_attributes["tomorrow_valid"] = True
+                
             else:
+                self._attr_extra_state_attributes["tomorrow_valid"] = False
                 _LOGGER.debug("No priceinfo for tomorrow")
             self._attr_extra_state_attributes["tomorrow"] = local_tomorrow
             self._attr_extra_state_attributes["raw_tomorrow"] = local_raw_tomorrow
         
         elif self.entity_description.key == "total_price":
             
-            self._attr_extra_state_attributes = {
-            "today": None,
-            "raw_today": None,
-            "tomorrow_valid": False,
-            "tomorrow": None,
-            "raw_tomorrow": None,
-            }
+            self._attr_extra_state_attributes = {}
             native_value = None
             
             priceinfo = self.coordinator.data.get("hourly_prices", {})
@@ -225,6 +206,7 @@ class TibberDataSensor(SensorEntity, CoordinatorEntity["TibberDataCoordinator"])
                 if (len(local_tomorrow) > 0):
                     self._attr_extra_state_attributes["tomorrow_valid"] = True
                 else:
+                    self._attr_extra_state_attributes["tomorrow_valid"] = False
                     _LOGGER.debug("No priceinfo for tomorrow")
                 self._attr_extra_state_attributes["tomorrow"] = local_tomorrow
                 self._attr_extra_state_attributes["raw_tomorrow"] = local_raw_tomorrow


### PR DESCRIPTION
- Add hourly prices including tax to data fetch

- Add new sensor energy price (electricity price incl tax)
- Add attributes with hourly prices today and tomorrow (if available) for energy price

- Add new sensor total price (electricity price incl tax and grid price)
- Add attributes with hourly prices today and tomorrow (if available) for total price

- Add attributes with hourly prices today and tomorrow (if available) for sensor grid price
